### PR TITLE
Terminology fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Use ST's inbuilt extension installer.
 Extensions > Timelines > View Timeline
 
 - Nodes with swipes will appear with a halo around them
-- Bookmarks appear with a colored ring around them
-- Bookmark paths will be colored and are visible in the legend
+- Checkpoints appear with a colored ring around them
+- Checkpoint paths will be colored and are visible in the legend
 - Long-pressing a node with swipes will reveal the swipes on the graph
 - Clicking a node will open the full info about it
 - Double clicking a node will go straight to the message

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An extension to allow for timeline based navigation of ST chat histories.
 ## Features
 
 - Display all chats with the current character. Chat messages with the same content will be shown as a single node on the timeline.
-- Search all current character message content with realtime fulltext filtering. 
+- Search all current character message content with realtime fulltext filtering.
 - Theming based on UI theme or custom theme.
 - Branch your chat from any chat or swipe
 
@@ -24,7 +24,7 @@ Extensions > Timeline > View Timeline
 - Bookmarks appear with a colored ring around them
 - Bookmark paths will be colored and are visible in the legend
 - Long-pressing a node with swipes will reveal the swipes on the graph
-- Clicking a node will open the full info about it 
+- Clicking a node will open the full info about it
 - Double clicking a node will go straight to the message
 
 The extension adds a slash command:
@@ -36,7 +36,7 @@ Binding the `/tl` command to a custom Quick Reply button gives convenient one-cl
 
 ## Prerequisites
 
-SillyTavern version  >=1.10.4
+SillyTavern version >=1.10.4
 
 ## Support and Contributions
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ Extensions > Timeline > View Timeline
 - Clicking a node will open the full info about it 
 - Double clicking a node will go straight to the message
 
+The extension adds a slash command:
+
+- `/tl` - open the timeline view
+- `/tl r` - refresh the timeline graph
+
+Binding the `/tl` command to a custom Quick Reply button gives convenient one-click access to the timeline view.
+
 ## Prerequisites
 
 SillyTavern version  >=1.10.4

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Use ST's inbuilt extension installer.
 
 ### Usage
 
-Extensions > Timeline > View Timeline
+Extensions > Timelines > View Timeline
 
 - Nodes with swipes will appear with a halo around them
 - Bookmarks appear with a colored ring around them

--- a/index.js
+++ b/index.js
@@ -449,7 +449,7 @@ function closeNodeModal() {
  *    - If a node with a unique name is found, its details (name and color)
  *      are added to the legend under the 'Nodes Legend' category.
  * 3. Iterates over all edges in the graph:
- *    - If an edge with a unique color is found, its details (bookmark name and color)
+ *    - If an edge with a unique color is found, its details (checkpoint name and color)
  *      are added to the legend under the 'Edges Legend' category.
  *
  * @param {Object} cy - The Cytoscape instance where graph operations are performed.

--- a/timeline.html
+++ b/timeline.html
@@ -127,7 +127,7 @@
             <div id="colorSettingsArea" class="hidden">
                 <div class="timeline-view-settings_block flex-container">
                     <toolcool-color-picker id="bookmark-color-picker" value="#ff0000"></toolcool-color-picker>
-                    <span data-i18n="Bookmark Color">Bookmark Color</span>
+                    <span data-i18n="Checkpoint Color">Checkpoint Color</span>
                 </div>
                 <div class="timeline-view-settings_block flex-container">
                     <toolcool-color-picker id="char-node-color-picker" value="#FFFFFF"></toolcool-color-picker>

--- a/timeline.html
+++ b/timeline.html
@@ -1,7 +1,7 @@
 <div class="timeline-view-settings">
     <div class="inline-drawer">
         <div class="inline-drawer-toggle inline-drawer-header">
-            <b>Timeline</b>
+            <b>Timelines</b>
             <div class="inline-drawer-icon fa-solid fa-circle-chevron-down down"></div>
         </div>
         <div class="inline-drawer-content">

--- a/tl_node_data.js
+++ b/tl_node_data.js
@@ -161,9 +161,9 @@ function buildNodes(allChats) {
 
 /**
  * Constructs a Cytoscape node object based on provided message details.
- * The function identifies special messages, such as bookmarks, and adjusts the node
+ * The function identifies special messages, such as checkpoints, and adjusts the node
  * properties accordingly. The returned node contains properties that help render and
- * differentiate it within the Cytoscape graph, such as color for bookmarks.
+ * differentiate it within the Cytoscape graph, such as color for checkpoints.
  *
  * @param {string} nodeId - The unique ID to assign to the node.
  * @param {string} parentNodeId - The ID of the node from which this node originates (previous message).
@@ -172,14 +172,14 @@ function buildNodes(allChats) {
  * @returns {Object} - A Cytoscape node object with properties set based on the message details.
  *
  * Behavior:
- * 1. Checks if any message in the group is a bookmark and extracts relevant details.
- * 2. Determines node properties, such as color for bookmarks, based on the message details.
+ * 1. Checks if any message in the group is a checkpoint and extracts relevant details.
+ * 2. Determines node properties, such as color for checkpoints, based on the message details.
  * 3. Constructs and returns the node object.
  */
 function createNode(nodeId, parentNodeId, text, group) {
     let bookmark = group.find(({ message }) => {
-        // Check if the message is from the system and if it indicates a bookmark
-        if (message.is_system && message.mes.includes('Bookmark created! Click here to open the bookmark chat')) return true;
+        // Check if the message is from the system and if it indicates a checkpoint
+        if (message.is_system && message.mes.includes('Checkpoint created! Click here to open the checkpoint chat')) return true;
 
         // Original bookmark case
         return !!message.extra && !!message.extra.bookmark_link;
@@ -187,7 +187,7 @@ function createNode(nodeId, parentNodeId, text, group) {
 
     let isBookmark = Boolean(bookmark);
 
-    // Extract bookmarkName and fileNameForNode depending on bookmark type
+    // Extract bookmarkName and fileNameForNode depending on checkpoint type
     let bookmarkName, fileNameForNode;
     if (isBookmark) {
         if (bookmark.message.extra && bookmark.message.extra.bookmark_link) {

--- a/tl_style.js
+++ b/tl_style.js
@@ -15,11 +15,11 @@ function getAlphaFromRGBA(rgbaString) {
 }
 
 /**
- * Highlights the path from a specified bookmark node to the root in a data structure representing a graph.
+ * Highlights the path from a specified checkpoint node to the root in a data structure representing a graph.
  * The function iteratively traces and highlights edges and nodes, adjusting visual attributes like color, thickness, and zIndex.
  *
  * @param {Object} rawData - The data structure representing the graph with nodes and edges.
- * @param {string|number} bookmarkNodeId - The ID of the bookmark node to start highlighting from.
+ * @param {string|number} bookmarkNodeId - The ID of the checkpoint node to start highlighting from.
  * @param {number} currentHighlightThickness - The starting thickness for highlighting edges (default is 4).
  * @param {number} startingZIndex - The starting zIndex for nodes and edges to be highlighted (default is 1000).
  */
@@ -29,7 +29,7 @@ function highlightPathToRoot(rawData, bookmarkNodeId, currentHighlightThickness 
     );
 
     if (!bookmarkNode) {
-        console.error('Bookmark node not found!');
+        console.error('Checkpoint node not found!');
         return;
     }
 
@@ -70,7 +70,7 @@ function highlightPathToRoot(rawData, bookmarkNodeId, currentHighlightThickness 
  * Sets up visual styles for nodes and edges based on provided node data and context settings.
  * This function prepares styles that are to be used with Cytoscape to visually represent a graph.
  * Depending on extension settings and context, different colors, shapes, and styles are applied to nodes and edges.
- * Additionally, paths from bookmarked nodes to the root are highlighted.
+ * Additionally, paths from checkpoint nodes to the root are highlighted.
  *
  * @param {Object} nodeData - Data structure representing the graph with nodes and edges.
  * @returns {Array} An array of style definitions suitable for use with Cytoscape.


### PR DESCRIPTION
This is getting ridiculous, but here's another PR. :)

As per https://github.com/SillyTavern/SillyTavern/issues/1739,

- Extension name is now consistently *Timelines* (plural!) also in the extension settings panel
- Terminology change to match ST 1.11.3: "bookmark" → "checkpoint"
  - Even the ST codebase still calls them bookmarks internally, so I changed only the user-visible strings and comments.
- Fix a check that didn't trigger after ST itself changed this terminology
- Mention the `/tl` slash command in the README
- Fix whitespace in README