### PR TITLE
UX improvements, some refactoring

### DIFF
--- a/timeline.html
+++ b/timeline.html
@@ -147,13 +147,15 @@
                 <!-- New button for comparison -->
             </div>
             <!-- The Modal -->
-            <div id="myModal" class="modal">
+            <div id="timelinesModal" class="modal">
                 <!-- Modal content -->
                 <div id="networkContainer">
                     <button class="close" title="Close">&times;</button>
                     <button class="rotate" title="Rotate Graph">&orarr;</button>
                     <button class="expand" title="Toggle Expand Swipes">&#x26D5;</button>
                     <button class="reload" title="Reload Graph [/tl r]">&#x1f5d8;</button>
+                    <button class="zoomtofit" title="Zoom to Fit">[]</button>
+                    <button class="zoomtocurrent" title="Zoom to Current Chat">&#x2b95;</button>
                     <input id="transparent-search" type="text" placeholder="Search..." />
                     <div class="graph-container">
                         <!-- Relative positioned container -->

--- a/tl_style.css
+++ b/tl_style.css
@@ -133,24 +133,59 @@
     padding: 0;
     padding-right: 10px;
 }
+/* The Zoom to Fit Button */
+.zoomtofit {
+    color: #aaaaaa;
+    float: right;
+    font-size: 20px;
+    font-weight: bold;
+    z-index: 3;
+    position: relative;
+    background: none;
+    border: none;
+    padding: 0;
+    padding-right: 10px;
+}
+/* The Zoom to Current Button */
+.zoomtocurrent {
+    color: #aaaaaa;
+    float: right;
+    font-size: 20px;
+    font-weight: bold;
+    z-index: 3;
+    position: relative;
+    background: none;
+    border: none;
+    padding: 0;
+    padding-right: 10px;
+}
 
-.rotate:hover,
-.rotate:focus {
-    color: black;
+.rotate:hover {
+    color: #808080;
     text-decoration: none;
     cursor: pointer;
 }
 
-.expand:hover,
-.expand:focus {
-    color: black;
+.expand:hover {
+    color: #808080;
     text-decoration: none;
     cursor: pointer;
 }
 
-.reload:hover,
-.reload:focus {
-    color: black;
+.reload:hover {
+    color: #808080;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.zoomtofit:hover {
+    color: #808080;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.zoomtocurrent:hover {
+    color: #808080;
     text-decoration: none;
     cursor: pointer;
 }
@@ -168,9 +203,8 @@ position: absolute;
     padding: 0;
 }
 
-.close:hover,
-.close:focus {
-    color: black;
+.close:hover {
+    color: red;
     text-decoration: none;
     cursor: pointer;
 }

--- a/tl_style.js
+++ b/tl_style.js
@@ -208,6 +208,14 @@ export function setupStylesAndData(nodeData) {
                 'line-opacity': .5,
             },
         },
+        {
+            selector: '.NoticeMe',  // This gets flashed on and off upon focusing the current chat node
+            style: {
+                'background-opacity': 0.5,
+                'width': extension_settings.timeline.nodeWidth * 0.9,
+                'height': extension_settings.timeline.nodeHeight * 0.9,
+            }
+        }
 
     ];
 


### PR DESCRIPTION
Here's the new PR for *Timelines*.

**NOTE**: Work in progress, likely for a day or two more. I'm posting this now to get the code out as early as possible. I'll post updates here.

**Changelog / DONE**:

- Ignore dead links when populating the graph - **no more checkpoint proliferation!**
  - **NOTE**: This catches the case where you create a checkpoint, and later delete (or rename) the spawned chat file. Now the resulting dead link in the originating chat file no longer matters.
  - This does **NOT** catch the opposite case. If you overwrite a checkpoint on a chat message that already has one, the old link is severed, a new chat file is spawned, and the link in the originating chat file now points to that new chat file. This means that the spawned chat file of the old checkpoint has become an independent chat, with no link to its originating chat. Old links are currently not preserved in the chat file format, so there's nothing the extension can (reasonably) do to this.
- Swipes:
  - Revised to how I felt the comments and docstrings indicated it was originally intended to be.
  - In `navigateToMessage`:
    - If `branch` is true, always create a new branch (as we did before)
    - If `branch` is false, attempt to avoid creating a branch (**no more branch proliferation** - previously, navigating to a swipe always created a branch)
      - If the swipes are on the last message in the chat, they are still available, so just navigate there
      - But if the swipes are on an older message, then create a branch so that we can reveal the stored swipes
  - GUI: On swipe nodes where the swipes are on an older message, disable the main button (and show it as disabled) on the node panel; the branch button ('→') is always available.
    - In other words, the main button is enabled whenever "navigate here without creating a branch" is possible.
  - GUI: Double-clicking on a node now Does What You Mean:
    - When possible, do not create branch, just navigate
    - But if double-clicking a swipe on an older message, create a branch
- GUI: When opening the timeline view, **auto-zoom to the current chat**, flashing the last node in it a few times to draw the user's attention
- GUI: **Text search: zoom to the matching elements** as you type, and zoom out if no match (or if you clear the search)
- GUI: Add toolbar button to **zoom out** to the whole graph
- GUI: Add toolbar button to **zoom to the current chat** (and flash the last node in it)
- GUI: Clicking a legend item now zooms to the matching elements, and zooms out when clicked again
  - The "clicked" status also resets if you click a legend item, but then do a text search
- GUI: All these new auto-zooms use padding, to show the matched region sensibly (e.g. show also the nodes at the endpoints of a checkpoint path)
  - Also "zoom out to the whole graph" leaves some padding at the edges (looks better)
- GUI: **Stable random color for named checkpoints**
  - Works by string-hashing the name and feeding that into a seedable RNG.
- Logging:
  - Use `debug`/`info`/`warning`/`error` levels explicitly, not the generic `log`.
  - `navigateToMessage`: If this goes wrong, it could be pretty hard to debug, so add enough log messages to figure out what it did and why.

**Still TODO**:

- Remove unused code (see TODOs marked in code comments)
- Settings: remove `Lock Nodes` (does nothing)
- Settings: add `Auto-expand Swipes` to start in "expand swipes" mode when the timeline view opens
- Settings: add `Max zoom level` (optional)
- Hotkeys (Esc to close; Ctrl+F to focus search text entry; Tab to jump between chat branches matching a search)
- Icon sizes at the top right of the timeline view should match each other.
