### PR TITLE
Multiparent and navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Actions:
 - *Opening the timeline view* auto-zooms to the current chat, and flashes the last node *in that chat* to clearly show it on the graph.
   - This might not be the latest node on the timeline, if there is another chat that still continues after that point.
   - There is also a button to zoom to the current chat.
-- *Hovering over a node* shows a short preview of the message text.
+- *Hovering over a node* shows a short preview of the message text, and highlights all of its incoming and outgoing edges.
 - *Long-pressing a node* with swipes reveals the swipes on the graph.
   - The timeline view allows you to see and access swipes also on previous messages, not just the last one.
   - There is also a *Toggle swipes* button to reveal/hide swipes for the whole graph.
@@ -63,6 +63,8 @@ Actions:
   - If you double-click a swipe node, what happens depends on whether it is the last node in that particular chat.
     - On the last node, double-clicking a swipe opens the original chat, goes to the last message, and switches to that swipe.
     - On a non-last node, double-clicking automatically creates a new branch, opens the new chat, goes to the (now-last) message, and switches to that swipe.
+- *Hovering over an edge* highlights that edge.
+- *Clicking an edge* navigates to its far end (as measured from the click position), and zooms into the node there.
 - *Clicking a legend entry* highlights it and zooms into it. Clicking the same entry again removes the highlight, and zooms out.
 - *Typing into fulltext search* highlights and zooms to the search results in realtime. When no match, or if you clear the search, it zooms out.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Actions:
   - If you double-click a swipe node, what happens depends on whether it is the last node in that particular chat.
     - On the last node, double-clicking a swipe opens the original chat, goes to the last message, and switches to that swipe.
     - On a non-last node, double-clicking automatically creates a new branch, opens the new chat, goes to the (now-last) message, and switches to that swipe.
-- *Clicking a legend entry* highlights it and zooms into it. Clicking the same entry again removes the highlight.
+- *Clicking a legend entry* highlights it and zooms into it. Clicking the same entry again removes the highlight, and zooms out.
 - *Typing into fulltext search* highlights and zooms to the search results in realtime. When no match, or if you clear the search, it zooms out.
 
 ### Checkpoints

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ For convenient one-click access, bind the `/tl` command to a custom Quick Reply 
 - *Checkpoint paths* are colored accordingly, and are shown in the legend.
   - The checkpoint color is random, but determined from the checkpoint name.
   - A checkpoint is detected only when there is an intact checkpoint link in the chat file that originated the checkpoint. Dead links are ignored.
+- The identical content auto-merge only combines messages at the same depth (sequential message number in the chat).
+  - Thus the graph is always [acyclic](https://en.wikipedia.org/wiki/Directed_acyclic_graph), even if you use the same canned *Quick Reply* at multiple points in the same chat.
+  - But chats that use the same *Quick Reply* at the same depth will all be routed through the node that represents that quick reply at that depth.
+
 
 Actions:
 

--- a/index.js
+++ b/index.js
@@ -844,7 +844,7 @@ function setupEventHandlers(cy, nodeData) {
         closeOpenDrawers();
     });
 
-    // Optional: Hide the tooltip if user taps anywhere else
+    // Hide the tooltip if user taps anywhere else
     cy.on('tap', function (evt) {
         if (evt.target === cy) {
             closeActiveTapTippy();

--- a/index.js
+++ b/index.js
@@ -852,10 +852,10 @@ function setupEventHandlers(cy, nodeData) {
     });
 
     cy.on('tap', 'node', function (evt) {
-        clearTimeout(showTimeout); // Clear any pending timeout for showing tooltip
+        clearTimeout(showTimeout);  // Clear any pending timeout for showing tooltip
         let node = evt.target;
         if (node._tippy) {
-            node._tippy.hide(); // Hide the tippy instance associated with the node
+            node._tippy.hide();  // Hide the tippy instance associated with the node
         }
         closeActiveTapTippy();
         activeTapTippy = makeTapTippy(node);

--- a/index.js
+++ b/index.js
@@ -364,7 +364,7 @@ function makeTapTippy(ele) {
                     const isLastMessage = (messageId === (session_metadata.length - 1));  // in this chat session
                     const isSwipe = Boolean(ele.data('isSwipe'));
 
-                    // Create jump to previous/next message buttons (but not on swipe nodes)
+                    // Create per-chat-session jump to previous/next message buttons (but not on swipe nodes)
                     function makeNextPrevMessageSelector(file_name, depthOffset) {
                         const selector = function (ele) {
                             if (ele.group() !== 'nodes') {

--- a/index.js
+++ b/index.js
@@ -395,7 +395,7 @@ function makeTapTippy(ele) {
                             zoom: Number(extension_settings.timeline.zoomToCurrentChatZoom),
                             duration: 300,  // Adjust the duration as needed for a smooth transition
                         });
-                        flashNode(newCenterNode, 2, 250);
+                        flashNode(newCenterNode, 3, 250);
                         newCenterNode.emit('tap');
                     });
                     if (isSwipe || messageId === 0) {
@@ -416,7 +416,7 @@ function makeTapTippy(ele) {
                             zoom: Number(extension_settings.timeline.zoomToCurrentChatZoom),
                             duration: 300,  // Adjust the duration as needed for a smooth transition
                         });
-                        flashNode(newCenterNode, 2, 250);
+                        flashNode(newCenterNode, 3, 250);
                         newCenterNode.emit('tap');
                     });
                     if (isSwipe || isLastMessage) {

--- a/index.js
+++ b/index.js
@@ -354,7 +354,7 @@ function makeTapTippy(ele) {
             const menuDiv = document.createElement('div');
             menuDiv.classList.add('menu_div');
             if (ele.data('chat_sessions')) {
-                for (const [file_name, session_metadata] of Object.entries(ele.data('chat_sessions'))) {
+                for (const [file_name, session_metadata] of Object.entries(ele.data('chat_sessions')).reverse()) {
                     // Create a container for the buttons
                     const btnContainer = document.createElement('div');
                     btnContainer.style.display = 'flex';

--- a/index.js
+++ b/index.js
@@ -373,7 +373,7 @@ function makeTapTippy(ele) {
                             const chat_depth = ele.data('chat_depth');
                             const chat_sessions = ele.data('chat_sessions');
                             const isSwipe = ele.data('isSwipe');  // this only exists (and is `true`) on swipe nodes
-                            if (chat_depth === undefined || chat_sessions === undefined) {  // likely not a node
+                            if (chat_depth === undefined || chat_sessions === undefined) {  // the root node doesn't have these
                                 return false;
                             }
                             if (chat_depth === (messageId + depthOffset) && !isSwipe && Object.keys(chat_sessions).includes(file_name)) {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 // @Technologicat's TODOs, early 2024:
 // TODO: Hotkeys (Tab to jump between chat branches matching a search).
-// TODO: Icon sizes at the top right of the timeline view should match each other.
 // TODO: Maybe refactor the closing of the Tippy tooltips into a one-size-fits-all solution. (Search for `closeModal` - the tooltips are closed when the modal is.)
 
 // @city-unit's original TODOs:

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 // @Technologicat's TODOs, early 2024:
-// TODO: Add prev/next buttons to full info panel actions to navigate along that chat history
 // TODO: Hotkeys (Tab to jump between chat branches matching a search).
 // TODO: Icon sizes at the top right of the timeline view should match each other.
 // TODO: Maybe refactor the closing of the Tippy tooltips into a one-size-fits-all solution. (Search for `closeModal` - the tooltips are closed when the modal is.)

--- a/index.js
+++ b/index.js
@@ -825,6 +825,7 @@ function setupEventHandlers(cy, nodeData) {
         zoomToCurrentChatNode(cy);
     };
 
+    // Close the node full info panel, if it is open.
     function closeActiveTapTippy() {
         if (activeTapTippy) {
             activeTapTippy.hide();

--- a/index.js
+++ b/index.js
@@ -563,12 +563,12 @@ function createLegendItem(cy, container, item, type) {
             highlightElements(cy, selector);
             legendItem.classList.add('active-legend');
             currentlyHighlighted = selector;
-
-            // Zoom to the highlighted elements
-            const [eles, padding] = filterElementsAndPad(cy, currentlyHighlighted);
-            cy.stop().animate({fit: { eles: eles, padding: padding },
-                               duration: 300});
         }
+
+        // Zoom to the highlighted elements (or zoom out if none)
+        const [eles, padding] = filterElementsAndPad(cy, currentlyHighlighted);
+        cy.stop().animate({fit: { eles: eles, padding: padding },
+                           duration: 300});
     });
 
     if (type === 'circle') {

--- a/index.js
+++ b/index.js
@@ -844,7 +844,7 @@ function setupEventHandlers(cy, nodeData) {
         closeOpenDrawers();
     });
 
-    // Hide the tooltip if user taps anywhere else
+    // Hide the node full info panel if user taps anywhere else
     cy.on('tap', function (evt) {
         if (evt.target === cy) {
             closeActiveTapTippy();

--- a/index.js
+++ b/index.js
@@ -825,6 +825,13 @@ function setupEventHandlers(cy, nodeData) {
         zoomToCurrentChatNode(cy);
     };
 
+    function closeActiveTapTippy() {
+        if (activeTapTippy) {
+            activeTapTippy.hide();
+            activeTapTippy = null;
+        }
+    }
+
     cy.ready(function () {
         if (extension_settings.timeline.showLegend) {
             createLegend(cy);
@@ -836,28 +843,22 @@ function setupEventHandlers(cy, nodeData) {
         closeOpenDrawers();
     });
 
+    // Optional: Hide the tooltip if user taps anywhere else
+    cy.on('tap', function (evt) {
+        if (evt.target === cy) {
+            closeActiveTapTippy();
+        }
+    });
+
     cy.on('tap', 'node', function (evt) {
         clearTimeout(showTimeout); // Clear any pending timeout for showing tooltip
         let node = evt.target;
         if (node._tippy) {
             node._tippy.hide(); // Hide the tippy instance associated with the node
         }
-        if (activeTapTippy) {
-            activeTapTippy.hide();
-        }
-        let tipInstance = makeTapTippy(node);
-
-        // Show the tooltip
-        tipInstance.show();
-
-        activeTapTippy = tipInstance;
-
-        // Optional: Hide the tooltip if user taps anywhere else
-        cy.on('tap', function (evt) {
-            if (evt.target === cy) {
-                tipInstance.hide();
-            }
-        });
+        closeActiveTapTippy();
+        activeTapTippy = makeTapTippy(node);
+        activeTapTippy.show();
     });
 
     // Handle double click on nodes for quickly navigating to the message
@@ -881,8 +882,8 @@ function setupEventHandlers(cy, nodeData) {
         } else {
             navigateToMessage(file_name, messageId);
         }
+        closeActiveTapTippy();
         closeModal();
-        activeTapTippy.hide();
     });
 
     function refreshLayout() {

--- a/index.js
+++ b/index.js
@@ -1033,13 +1033,14 @@ function setupEventHandlers(cy, nodeData) {
         const d2_target = dx2_target + dy2_target;
 
         // Center and zoom in to the node that is farther away from the click position
-        let farawayNode = (d2_source > d2_target) ? sourceNode : targetNode;
+        let newCenterNode = (d2_source > d2_target) ? sourceNode : targetNode;
         cy.stop().animate({
-            center: { eles: farawayNode },
+            center: { eles: newCenterNode },
             zoom: Number(extension_settings.timeline.zoomToCurrentChatZoom),
             duration: 300,  // Adjust the duration as needed for a smooth transition
         });
-        flashNode(farawayNode, 4, 500);
+        flashNode(newCenterNode, 3, 250);
+        newCenterNode.emit('tap');
     });
 
     // Tap a node to open the full info panel

--- a/timeline.html
+++ b/timeline.html
@@ -62,40 +62,42 @@
                     <input id="tl_zoom_max" type="range" class="floatingpoint" min="0.1" max="10.0" step="0.1" />
                 </div>
                 <small>
-                    All sizes are specified in pixels at zoom level 1.0. The size set here multiplied by the zoom level is the final on-screen size. See <a href="https://js.cytoscape.org/">Cytoscape documentation</a> for the exact meanings of the settings.
+                    All sizes are specified in pixels at zoom level 1.0. The size set here multiplied by the zoom level is the final on-screen size. <!-- See <a href="https://js.cytoscape.org/">Cytoscape documentation</a> for the exact meanings of the settings. -->
                 </small>
                 <div class="timeline-view-settings_block flex-container">
-                    <label for="tl_node_width">Node Width (<span id="tl_node_width_value"></span>)</label>
+                    <label for="tl_node_width" title="Width of a node, in pixels at zoom level 1.0." data-i18n="[title]Width of a node, in pixels at zoom level 1.0.">Node Width (<span id="tl_node_width_value"></span>)</label>
                     <input id="tl_node_width" type="range" min="1" max="100" />
                 </div>
                 <div class="timeline-view-settings_block flex-container">
-                    <label for="tl_node_height">Node Height (<span id="tl_node_height_value"></span>)</label>
+                    <label for="tl_node_height" title="Height of a node, in pixels at zoom level 1.0." data-i18n="[title]Height of a node, in pixels at zoom level 1.0.">Node Height (<span id="tl_node_height_value"></span>)</label>
                     <input id="tl_node_height" type="range" min="1" max="100" />
                 </div>
                 <div class="timeline-view-settings_block flex-container">
-                    <label for="tl_node_separation"
-                        >Node Separation (<span id="tl_node_separation_value"></span>)</label
-                    >
+                    <label for="tl_node_separation" title="Separation between adjacent nodes in the same rank." data-i18n="[title]Separation between adjacent nodes in the same rank.">Node Separation (<span id="tl_node_separation_value"></span>)</label>
                     <input id="tl_node_separation" type="range" min="1" max="100" />
                 </div>
                 <div class="timeline-view-settings_block flex-container">
-                    <label for="tl_edge_separation"
-                        >Edge Separation (<span id="tl_edge_separation_value"></span>)</label
-                    >
+                    <label for="tl_edge_separation" title="Separation between adjacent edges in the same rank." data-i18n="[title]Separation between adjacent edges in the same rank.">Edge Separation (<span id="tl_edge_separation_value"></span>)</label>
                     <input id="tl_edge_separation" type="range" min="1" max="100" />
                 </div>
                 <div class="timeline-view-settings_block flex-container">
-                    <label for="tl_rank_separation"
-                        >Rank Separation (<span id="tl_rank_separation_value"></span>)</label
-                    >
+                    <label for="tl_rank_separation" title="Separation between each rank in the layout." data-i18n="[title]Separation between each rank in the layout.">Rank Separation (<span id="tl_rank_separation_value"></span>)</label>
                     <input id="tl_rank_separation" type="range" min="1" max="100" />
                 </div>
                 <div class="timeline-view-settings_block flex-container">
-                    <label for="tl_spacing_factor">Spacing Factor (<span id="tl_spacing_factor_value"></span>)</label>
+                    <label for="tl_spacing_factor" title="A multiplicative factor to expand the overall area that the nodes take up." data-i18n="[title]A multiplicative factor to expand the overall area that the nodes take up.">Spacing Factor (<span id="tl_spacing_factor_value"></span>)</label>
                     <input id="tl_spacing_factor" type="range" min="1" max="100" />
                 </div>
                 <div class="timeline-view-settings_block flex-container">
-                    <label for="tl_node_shape">Node Shape</label>
+                    <label for="tl_node_ranker" title="How the automatic graph builder assigns a rank (layout depth) to graph nodes." data-i18n="[title]How the automatic graph builder assigns a rank (layout depth) to graph nodes.">Node Ranking Algorithm</label>
+                    <select id="tl_node_ranker">
+                        <option value="tight-tree">Tight Tree</option>
+                        <option value="network-simplex">Network Simplex</option>
+                        <option value="longest-path">Longest Path</option>
+                    </select>
+                </div>
+                <div class="timeline-view-settings_block flex-container">
+                    <label for="tl_node_shape" title="The visual appearance of a node in the graph." data-i18n="[title]The visual appearance of a node in the graph.">Node Shape</label>
                     <select id="tl_node_shape">
                         <option value="ellipse">Ellipse</option>
                         <option value="triangle">Triangle</option>
@@ -126,7 +128,7 @@
                 </div>
 
                 <div class="timeline-view-settings_block flex-container">
-                    <label for="tl_curve_style">Curve Style</label>
+                    <label for="tl_curve_style" title="Style and routing of graph edges." data-i18n="[title]Style and routing of graph edges.">Curve Style</label>
                     <select id="tl_curve_style">
                         <option value="haystack">Haystack</option>
                         <option value="straight">Straight</option>
@@ -138,7 +140,11 @@
                     </select>
                 </div>
                 <div class="timeline-view-settings_block flex-container">
-                    <label for="tl_align">Alignment</label>
+                    <!-- Whatever that means. The phrase comes from the Cytoscape-Dagre README:
+                           https://github.com/cytoscape/cytoscape.js-dagre
+                           https://js.cytoscape.org/#layouts
+                    -->
+                    <label for="tl_align" title="Alignment for rank nodes." data-i18n="[title]Alignment for rank nodes.">Alignment</label>
                     <select id="tl_align">
                         <option value="UL">Upper Left</option>
                         <option value="UR">Upper Right</option>
@@ -147,7 +153,7 @@
                     </select>
                 </div>
                 <div class="timeline-view-settings_block flex-container">
-                    <input value="Reset Settings" class="menu_button" type="submit" id="resetSettingsBtn">
+                    <input value="Reset Settings" class="menu_button" type="submit" id="resetSettingsBtn" title="Reset all Timelines settings to their default values." data-i18n="[title]Reset all Timelines settings to their default values.">
                 </div>
             </div>
             <div class="timeline-view-settings_block flex-container">
@@ -156,7 +162,7 @@
             <div id="colorSettingsArea" class="hidden">
                 <div class="timeline-view-settings_block flex-container">
                     <toolcool-color-picker id="bookmark-color-picker" value="#ff0000"></toolcool-color-picker>
-                    <span data-i18n="Checkpoint Color">Checkpoint Color</span>
+                    <span data-i18n="Checkpoint Color">Checkpoint Node Border Color</span>
                 </div>
                 <div class="timeline-view-settings_block flex-container">
                     <toolcool-color-picker id="char-node-color-picker" value="#FFFFFF"></toolcool-color-picker>

--- a/tl_node_data.js
+++ b/tl_node_data.js
@@ -251,7 +251,7 @@ function createNode(nodeId, messageId, text, group, allChatFileNamesAndLengths) 
     for (const {file_name, index} of group) {
         // console.debug(`messageId (in chat) ${messageId}: graph node '${nodeId}' for chat '${file_name}' [${allChatFileNamesAndLengths[file_name]} messages]`);
         chat_sessions[file_name] = {
-            messageId: messageId,
+            messageId: messageId,  // we don't strictly need this per-session copy of `messageId`, but it's sometimes convenient.
             indexInGroup: index,
             length: allChatFileNamesAndLengths[file_name],
         };
@@ -260,12 +260,13 @@ function createNode(nodeId, messageId, text, group, allChatFileNamesAndLengths) 
     return {
         id: nodeId,
         msg: text,
+        chat_depth: messageId,  // same for all messages in the same message group
         isBookmark: isBookmark,
         bookmarkName: bookmarkName,
         file_name: fileNameForNode,
         is_name: is_name,
         is_user: is_user,
-        is_system: is_system,  // Added is_system to node properties
+        is_system: is_system,
         name: name,
         send_date: send_date,
         color: isBookmark ? generateUniqueColor(text) : null,

--- a/tl_node_data.js
+++ b/tl_node_data.js
@@ -97,6 +97,7 @@ function buildGraph(allChats, allChatFileNamesAndLengths) {
                 uniqueSwipes = [...new Set(allSwipes)].filter(swipeText => swipeText !== text);
             }
 
+            // Treat each message in this message group. A message may have multiple parents (happens for a canned reply, used in several chats at the same chat depth).
             const uniqueParents = new Set();
             for (const messageObj of group) {
                 const parentNodeId = previousNodes[messageObj.file_name];

--- a/tl_style.js
+++ b/tl_style.js
@@ -217,8 +217,6 @@ export function setupStylesAndData(nodeData) {
             selector: '.NoticeMe',  // This gets flashed on and off upon zooming to the current chat node
             style: {
                 'background-opacity': 0.5,
-                'width': extension_settings.timeline.nodeWidth * 0.9,
-                'height': extension_settings.timeline.nodeHeight * 0.9,
             }
         }
 

--- a/tl_utils.js
+++ b/tl_utils.js
@@ -169,6 +169,7 @@ export function closeTippy() {
         let parent = box.parentElement;
         if (parent && parent._tippy) {  // `_tippy` is stored on the graph node
             parent._tippy.hide();
+            parent._tippy = null;
         }
     });
 }


### PR DESCRIPTION
Might as well post this now.

This set is almost complete, final touches in progress.

It seems that the nearer you get to getting the UX to feel just right, the smaller the things that start feeling like major usability roadblocks.

**Changelog**

- The graph builder now understands nodes that have multiple parent nodes.
  - This means timelines can now converge as well as diverge.
  - This occurs when you send the same canned reply at the same chat depth in different chat sessions - for example, when using the script I posted in https://github.com/SillyTavern/SillyTavern/issues/1777.
  - If you're polite when talking to AI, this can also happen when you send just *"Thanks!"*.
  - Previous versions simply connected the node only to its first detected parent.
- The node ranking algorithm can now be chosen in the settings
  - Previous versions used `network-simplex`, new default is `tight-tree`
  - `tight-tree` better deals with the resulting mess when nodes with multiple parents exist.
- Hover over an edge to highlight it
- Hover over node (or click it open) to highlight all its connected edges
- Click an edge to jump to its far end
  - "Far" is measured from the clicked position to the positions of the connected nodes, picking the one further away
  - This is convenient for navigating along long edges in the graph
- The node full info panel now has buttons, per timeline, to jump to next/previous message in that timeline
  - This is convenient when edges overlap in the layout
- The button rows in the full info panel are now in the same visual order as the nodes in the graph (when using default layout settings).
  - It's alphabetical, so the newest items appear at the bottom for now.

**Screenshot**

Multiple parent nodes, edge highlighting, and the new navigation buttons.

![image](https://github.com/SillyTavern/SillyTavern-Timelines/assets/16972251/26970cf6-1bc2-4e8f-b83b-af9bf9a2aa35)
